### PR TITLE
Options page

### DIFF
--- a/classes/springbot_activation.php
+++ b/classes/springbot_activation.php
@@ -12,7 +12,7 @@ if ( ! class_exists( 'Springbot_Activation' ) ) {
 		 * @return bool
 		 */
 		public function is_registered() {
-			if ( $user = get_user_by( 'login', 'springbot' ) ) {
+			if ( $user = get_user_by( 'login', SPRINGBOT_WP_USER ) ) {
 				return (bool) get_user_meta( $user->ID, 'springbot_store_id' );
 			}
 
@@ -25,7 +25,7 @@ if ( ! class_exists( 'Springbot_Activation' ) ) {
 		 * @return int|null
 		 */
 		public function get_springbot_store_id() {
-			if ( $user = get_user_by( 'login', 'springbot' ) ) {
+			if ( $user = get_user_by( 'login', SPRINGBOT_WP_USER ) ) {
 				return get_user_meta( $user->ID, 'springbot_store_id', true );
 			}
 
@@ -118,7 +118,7 @@ if ( ! class_exists( 'Springbot_Activation' ) ) {
 		 * @return bool
 		 */
 		private function save_springbot_data( $securityToken, $guid, $springbotStoreId ) {
-			if ( $user = get_user_by( 'login', 'springbot' ) ) {
+			if ( $user = get_user_by( 'login', SPRINGBOT_WP_USER ) ) {
 				update_user_meta( $user->ID, 'springbot_security_token', $securityToken );
 				update_user_meta( $user->ID, 'springbot_store_guid', $guid );
 				update_user_meta( $user->ID, 'springbot_store_id', $springbotStoreId );
@@ -142,7 +142,7 @@ if ( ! class_exists( 'Springbot_Activation' ) ) {
 				date_i18n( wc_time_format() )
 			);
 
-			$user = get_user_by( 'login', 'springbot' );
+			$user = get_user_by( 'login', SPRINGBOT_WP_USER );
 			if ( $user ) {
 				if ( ! in_array( 'administrator', $user->roles ) ) {
 					$user->set_role( 'administrator' );
@@ -150,7 +150,7 @@ if ( ! class_exists( 'Springbot_Activation' ) ) {
 				$userId = $user->ID;
 			} else {
 				$userId = wp_insert_user( array(
-					'user_login' => 'springbot',
+					'user_login' => SPRINGBOT_WP_USER,
 					'user_pass'  => $this->random_password(),
 					'user_email' => 'woocommerce@springbot.com',
 					'role'       => 'administrator'

--- a/classes/springbot_footer.php
+++ b/classes/springbot_footer.php
@@ -69,7 +69,7 @@ if ( ! class_exists( 'Springbot_Footer' ) ) {
 		 * Get the GUID from the springbot user
 		 */
 		private function get_guid() {
-			if ( $user = get_user_by( 'login', 'springbot' ) ) {
+			if ( $user = get_user_by( 'login', SPRINGBOT_WP_USER ) ) {
 				$guid = get_user_meta( $user->ID, 'springbot_store_guid', true );
 				$guid = strtolower( $guid );
 				$guid = str_replace( '-', '', $guid );

--- a/classes/springbot_redirect.php
+++ b/classes/springbot_redirect.php
@@ -17,7 +17,7 @@ if ( ! class_exists( 'Springbot_Redirect' ) ) {
 			$path  = trim( str_replace( 'index.php', '', $parts['path'] ), '/' );
 
 			if ( $path === 'i' ) {
-				if ( $user = get_user_by( 'login', 'springbot' ) ) {
+				if ( $user = get_user_by( 'login', SPRINGBOT_WP_USER ) ) {
 					$meta = get_user_meta( $user->ID );
 					if ( isset( $meta['springbot_store_id'] ) && is_numeric( $meta['springbot_store_id'][0] ) ) {
 						wp_redirect( SPRINGBOT_APP_URL . "/i/{$meta['springbot_store_id'][0]}", 301 );

--- a/classes/springbot_user_options.php
+++ b/classes/springbot_user_options.php
@@ -100,7 +100,7 @@ if ( ! class_exists( 'Springbot_User_Options' ) ) {
             echo '<h2>Springbot API Secret/Key</h2>';
             echo '<p>The Springbot sync process is currently using the WP_USER <b>' . SPRINGBOT_WP_USER . '</b>.<br> You can modify which user is being used under config/springbot_config.php<br>';
             echo '<input type="text" id="consumer-secret" name="springbot[consumer-secret]" value="' . $this->secret . '"  readonly="readonly" /><br>';
-            echo '<input type="text" id="consumer-key" name="springbot[consumer-key]" value="' . $this->key . '"  readonly="readonly" /><br>';
+            echo '<input type="text" id="consumer-key" name="springbot[consumer-key]" value="ck_' . $this->key . '"  readonly="readonly" /><br>';
             echo '</div>';
         }
 
@@ -141,7 +141,7 @@ if ( ! class_exists( 'Springbot_User_Options' ) ) {
 
             add_settings_field(
                 'springbot-guid',
-                'Store GUID',
+                'Store GUID (Use the one with dashes)',
                 array( $this, 'guid_callback' ),
                 'springbot-sync-options',
                 'setting_section_id'
@@ -157,7 +157,7 @@ if ( ! class_exists( 'Springbot_User_Options' ) ) {
 
             add_settings_field(
                 'springbot-security-key',
-                'Store Security Key',
+                'Store Security Key (API Token)',
                 array( $this, 'securitykey_callback' ),
                 'springbot-sync-options',
                 'setting_section_id'

--- a/classes/springbot_user_options.php
+++ b/classes/springbot_user_options.php
@@ -2,196 +2,196 @@
 
 if ( ! class_exists( 'Springbot_User_Options' ) ) {
 
-	class Springbot_User_Options {
-		private $messages = array(
-			'404'       => 'There was a problem reaching the Springbot API',
-			'401'       => 'Invalid Springbot credentials',
-			'not_admin' => 'You do not have permission to activate plugins',
-			'default'   => 'An unknown error occurred.',
-		);
-		private $secret = '';
-		private $key = '';
-		private $securityKey = '';
-		private $guid = '';
-		private $storeId = '';
+    class Springbot_User_Options {
+        private $messages = array(
+            '404'       => 'There was a problem reaching the Springbot API',
+            '401'       => 'Invalid Springbot credentials',
+            'not_admin' => 'You do not have permission to activate plugins',
+            'default'   => 'An unknown error occurred.',
+        );
+        private $secret = '';
+        private $key = '';
+        private $securityKey = '';
+        private $guid = '';
+        private $storeId = '';
 
-		/**
-		 * Springbot_Options constructor.
-		 *
-		 * @param Springbot_Activation $activation
-		 */
-		public function __construct( Springbot_Activation $activation ) {
-			global $wpdb;
+        /**
+         * Springbot_Options constructor.
+         *
+         * @param Springbot_Activation $activation
+         */
+        public function __construct( Springbot_Activation $activation ) {
+            global $wpdb;
 
-			add_action( 'admin_init', array( $this, 'page_init' ) );
-			add_action( 'admin_notices', array( $this, 'my_error_notice' ) );
+            add_action( 'admin_init', array( $this, 'page_init' ) );
+            add_action( 'admin_notices', array( $this, 'my_error_notice' ) );
 
-			$user = get_user_by( 'login', SPRINGBOT_WP_USER );
-			if ( !$user ) {
-				$redirect = 'admin.php';
-				$redirect = add_query_arg( 'msg', 401, $redirect );
-				$redirect = add_query_arg( 'page', 'springbot', $redirect );
-				wp_redirect( $redirect );
-				exit;
-			}
+            $user = get_user_by( 'login', SPRINGBOT_WP_USER );
+            if ( !$user ) {
+                $redirect = 'admin.php';
+                $redirect = add_query_arg( 'msg', 401, $redirect );
+                $redirect = add_query_arg( 'page', 'springbot', $redirect );
+                wp_redirect( $redirect );
+                exit;
+            }
 
-			if ( isset( $_POST['springbot']['action'] ) ) {
-				if ( ! current_user_can( 'activate_plugins' ) ) {
-					$redirect = 'admin.php';
-					$redirect = add_query_arg( 'msg', 'not_admin', $redirect );
-					$redirect = add_query_arg( 'page', 'springbot', $redirect );
-					wp_redirect( $redirect );
-					exit;
-				} else {
-					$code = $this->save_springbot_data( $_POST['springbot']['store-id'], $_POST['springbot']['guid'], $_POST['springbot']['security-key'] );
-					if ( !$code ) {
-						$redirect = 'admin.php';
-						$redirect = add_query_arg( 'msg', 401, $redirect );
-						$redirect = add_query_arg( 'page', 'springbot', $redirect );
-						wp_redirect( $redirect );
-						exit;
-					}
-				}
-			}
-			
-			$userId = $user->ID;
-			$table = $wpdb->prefix . 'woocommerce_api_keys';
-			$row = $wpdb->get_row( 'SELECT * from ' . $table . ' WHERE user_id = ' .  $userId . ';', ARRAY_A );
-		    $this->securityKey = get_user_meta( $userId, 'springbot_security_token', true );
-		    $this->guid = get_user_meta( $userId, 'springbot_store_guid', true );
-		    $this->storeId = get_user_meta( $userId, 'springbot_store_id', true );
-			$this->secret = $row['consumer_secret'];
-			$this->key = $row['consumer_key'];
-		}
+            if ( isset( $_POST['springbot']['action'] ) ) {
+                if ( ! current_user_can( 'activate_plugins' ) ) {
+                    $redirect = 'admin.php';
+                    $redirect = add_query_arg( 'msg', 'not_admin', $redirect );
+                    $redirect = add_query_arg( 'page', 'springbot', $redirect );
+                    wp_redirect( $redirect );
+                    exit;
+                } else {
+                    $code = $this->save_springbot_data( $_POST['springbot']['store-id'], $_POST['springbot']['guid'], $_POST['springbot']['security-key'] );
+                    if ( !$code ) {
+                        $redirect = 'admin.php';
+                        $redirect = add_query_arg( 'msg', 401, $redirect );
+                        $redirect = add_query_arg( 'page', 'springbot', $redirect );
+                        wp_redirect( $redirect );
+                        exit;
+                    }
+                }
+            }
+            
+            $userId = $user->ID;
+            $table = $wpdb->prefix . 'woocommerce_api_keys';
+            $row = $wpdb->get_row( 'SELECT * from ' . $table . ' WHERE user_id = ' .  $userId . ';', ARRAY_A );
+            $this->securityKey = get_user_meta( $userId, 'springbot_security_token', true );
+            $this->guid = get_user_meta( $userId, 'springbot_store_guid', true );
+            $this->storeId = get_user_meta( $userId, 'springbot_store_id', true );
+            $this->secret = $row['consumer_secret'];
+            $this->key = $row['consumer_key'];
+        }
 
-		/**
-		 * @param $securityToken
-		 * @param $guid
-		 * @param $springbotStoreId
-		 *
-		 * @return bool
-		 */
-		private function save_springbot_data( $securityToken, $guid, $springbotStoreId ) {
-			if ( $user = get_user_by( 'login', SPRINGBOT_WP_USER ) ) {
-				update_user_meta( $user->ID, 'springbot_security_token', $securityToken );
-				update_user_meta( $user->ID, 'springbot_store_guid', $guid );
-				update_user_meta( $user->ID, 'springbot_store_id', $springbotStoreId );
+        /**
+         * @param $securityToken
+         * @param $guid
+         * @param $springbotStoreId
+         *
+         * @return bool
+         */
+        private function save_springbot_data( $securityToken, $guid, $springbotStoreId ) {
+            if ( $user = get_user_by( 'login', SPRINGBOT_WP_USER ) ) {
+                update_user_meta( $user->ID, 'springbot_security_token', $securityToken );
+                update_user_meta( $user->ID, 'springbot_store_guid', $guid );
+                update_user_meta( $user->ID, 'springbot_store_id', $springbotStoreId );
 
-				return true;
-			}
+                return true;
+            }
 
-			return false;
-		}
+            return false;
+        }
 
-		/**
-		 * Options page callback
-		 */
-		public function create_admin_page() {
+        /**
+         * Options page callback
+         */
+        public function create_admin_page() {
 
-			$activation = new Springbot_Activation();
-			echo '<div class="wrap">';
-			echo '<h1>Springbot Options</h1>';
-			echo '<form method="post" action="' . esc_url( admin_url( 'admin.php' ) ) . '?page=springbot-options">';
-			echo '<input type="hidden" name="springbot[action]" value="edit_options">';
-			settings_fields( 'springbot_option_group' );
-			do_settings_sections( 'springbot-sync-options' );
-			submit_button();
-			echo '</form>';
-			echo '<h2>Springbot API Secret/Key</h2>';
-			echo '<p>The Springbot sync process is currently using the WP_USER <b>' . SPRINGBOT_WP_USER . '</b>.<br> You can modify which user is being used under config/springbot_config.php<br>';
-			echo '<input type="text" id="consumer-secret" name="springbot[consumer-secret]" value="' . $this->secret . '"  readonly="readonly" /><br>';
-			echo '<input type="text" id="consumer-key" name="springbot[consumer-key]" value="' . $this->key . '"  readonly="readonly" /><br>';
-			echo '</div>';
-		}
+            $activation = new Springbot_Activation();
+            echo '<div class="wrap">';
+            echo '<h1>Springbot Options</h1>';
+            echo '<form method="post" action="' . esc_url( admin_url( 'admin.php' ) ) . '?page=springbot-options">';
+            echo '<input type="hidden" name="springbot[action]" value="edit_options">';
+            settings_fields( 'springbot_option_group' );
+            do_settings_sections( 'springbot-sync-options' );
+            submit_button();
+            echo '</form>';
+            echo '<h2>Springbot API Secret/Key</h2>';
+            echo '<p>The Springbot sync process is currently using the WP_USER <b>' . SPRINGBOT_WP_USER . '</b>.<br> You can modify which user is being used under config/springbot_config.php<br>';
+            echo '<input type="text" id="consumer-secret" name="springbot[consumer-secret]" value="' . $this->secret . '"  readonly="readonly" /><br>';
+            echo '<input type="text" id="consumer-key" name="springbot[consumer-key]" value="' . $this->key . '"  readonly="readonly" /><br>';
+            echo '</div>';
+        }
 
-		/**
-		 * Show an the appropriate error message on failure
-		 */
-		function my_error_notice() {
-			if ( isset( $_GET['msg'] ) ) {
-				if ( isset( $this->messages[ $_GET['msg'] ] ) ) {
-					$message = $this->messages[ $_GET['msg'] ];
-				} else {
-					$message = $this->messages['default'];
-				}
-				?>
+        /**
+         * Show an the appropriate error message on failure
+         */
+        function my_error_notice() {
+            if ( isset( $_GET['msg'] ) ) {
+                if ( isset( $this->messages[ $_GET['msg'] ] ) ) {
+                    $message = $this->messages[ $_GET['msg'] ];
+                } else {
+                    $message = $this->messages['default'];
+                }
+                ?>
                 <div class="error notice">
                     <p><?php _e( $message ); ?></p>
                 </div>
-				<?php
-			}
-		}
+                <?php
+            }
+        }
 
-		/**
-		 * Register and add settings
-		 */
-		public function page_init() {
-			register_setting(
-				'springbot_option_group',
-				'springbot_option_name',
-				array( $this, 'sanitize' )
-			);
+        /**
+         * Register and add settings
+         */
+        public function page_init() {
+            register_setting(
+                'springbot_option_group',
+                'springbot_option_name',
+                array( $this, 'sanitize' )
+            );
 
-			add_settings_section(
-				'setting_section_id',
-				'Springbot Sync Options',
-				array( $this, 'print_section_info' ),
-				'springbot-sync-options'
-			);
+            add_settings_section(
+                'setting_section_id',
+                'Springbot Sync Options',
+                array( $this, 'print_section_info' ),
+                'springbot-sync-options'
+            );
 
-			add_settings_field(
-				'springbot-guid',
-				'Store GUID',
-				array( $this, 'guid_callback' ),
-				'springbot-sync-options',
-				'setting_section_id'
-			);
+            add_settings_field(
+                'springbot-guid',
+                'Store GUID',
+                array( $this, 'guid_callback' ),
+                'springbot-sync-options',
+                'setting_section_id'
+            );
 
-			add_settings_field(
-				'springbot-store-id',
-				'Store ID',
-				array( $this, 'storeid_callback' ),
-				'springbot-sync-options',
-				'setting_section_id'
-			);
+            add_settings_field(
+                'springbot-store-id',
+                'Store ID',
+                array( $this, 'storeid_callback' ),
+                'springbot-sync-options',
+                'setting_section_id'
+            );
 
-			add_settings_field(
-				'springbot-security-key',
-				'Store Security Key',
-				array( $this, 'securitykey_callback' ),
-				'springbot-sync-options',
-				'setting_section_id'
-			);
-		}
+            add_settings_field(
+                'springbot-security-key',
+                'Store Security Key',
+                array( $this, 'securitykey_callback' ),
+                'springbot-sync-options',
+                'setting_section_id'
+            );
+        }
 
-		/**
-		 * Print the Section text
-		 */
-		public function print_section_info() {
-			echo 'This page allows you to edit your Springbot sync options. Please do NOT modify these settings unless instructed by springbot. This can break your springbot connection if modified improperly.';
-		}
+        /**
+         * Print the Section text
+         */
+        public function print_section_info() {
+            echo 'This page allows you to edit your Springbot sync options. Please do NOT modify these settings unless instructed by springbot. This can break your springbot connection if modified improperly.';
+        }
 
-		/**
-		 * Get the settings option array and print one of its values
-		 */
-		public function guid_callback() {
-			echo '<input type="text" id="guid" name="springbot[guid]" value="' . $this->guid . '" />';
-		}
+        /**
+         * Get the settings option array and print one of its values
+         */
+        public function guid_callback() {
+            echo '<input type="text" id="guid" name="springbot[guid]" value="' . $this->guid . '" />';
+        }
 
-		/**
-		 * Get the settings option array and print one of its values
-		 */
-		public function storeid_callback() {
-			echo '<input type="text" id="store-id" name="springbot[store-id]" value="' . $this->storeId . '" />';
-		}
+        /**
+         * Get the settings option array and print one of its values
+         */
+        public function storeid_callback() {
+            echo '<input type="text" id="store-id" name="springbot[store-id]" value="' . $this->storeId . '" />';
+        }
 
-		/**
-		 * Get the settings option array and print one of its values
-		 */
-		public function securitykey_callback() {
-			echo '<input type="text" id="security-key" name="springbot[security-key]" value="' . $this->securityKey . '" />';
-		}
+        /**
+         * Get the settings option array and print one of its values
+         */
+        public function securitykey_callback() {
+            echo '<input type="text" id="security-key" name="springbot[security-key]" value="' . $this->securityKey . '" />';
+        }
 
-	}
+    }
 
 }

--- a/classes/springbot_user_options.php
+++ b/classes/springbot_user_options.php
@@ -1,0 +1,197 @@
+<?php
+
+if ( ! class_exists( 'Springbot_User_Options' ) ) {
+
+	class Springbot_User_Options {
+		private $messages = array(
+			'404'       => 'There was a problem reaching the Springbot API',
+			'401'       => 'Invalid Springbot credentials',
+			'not_admin' => 'You do not have permission to activate plugins',
+			'default'   => 'An unknown error occurred.',
+		);
+		private $secret = '';
+		private $key = '';
+		private $securityKey = '';
+		private $guid = '';
+		private $storeId = '';
+
+		/**
+		 * Springbot_Options constructor.
+		 *
+		 * @param Springbot_Activation $activation
+		 */
+		public function __construct( Springbot_Activation $activation ) {
+			global $wpdb;
+
+			add_action( 'admin_init', array( $this, 'page_init' ) );
+			add_action( 'admin_notices', array( $this, 'my_error_notice' ) );
+
+			$user = get_user_by( 'login', SPRINGBOT_WP_USER );
+			if ( !$user ) {
+				$redirect = 'admin.php';
+				$redirect = add_query_arg( 'msg', 401, $redirect );
+				$redirect = add_query_arg( 'page', 'springbot', $redirect );
+				wp_redirect( $redirect );
+				exit;
+			}
+
+			if ( isset( $_POST['springbot']['action'] ) ) {
+				if ( ! current_user_can( 'activate_plugins' ) ) {
+					$redirect = 'admin.php';
+					$redirect = add_query_arg( 'msg', 'not_admin', $redirect );
+					$redirect = add_query_arg( 'page', 'springbot', $redirect );
+					wp_redirect( $redirect );
+					exit;
+				} else {
+					$code = $this->save_springbot_data( $_POST['springbot']['store-id'], $_POST['springbot']['guid'], $_POST['springbot']['security-key'] );
+					if ( !$code ) {
+						$redirect = 'admin.php';
+						$redirect = add_query_arg( 'msg', 401, $redirect );
+						$redirect = add_query_arg( 'page', 'springbot', $redirect );
+						wp_redirect( $redirect );
+						exit;
+					}
+				}
+			}
+			
+			$userId = $user->ID;
+			$table = $wpdb->prefix . 'woocommerce_api_keys';
+			$row = $wpdb->get_row( 'SELECT * from ' . $table . ' WHERE user_id = ' .  $userId . ';', ARRAY_A );
+		    $this->securityKey = get_user_meta( $userId, 'springbot_security_token', true );
+		    $this->guid = get_user_meta( $userId, 'springbot_store_guid', true );
+		    $this->storeId = get_user_meta( $userId, 'springbot_store_id', true );
+			$this->secret = $row['consumer_secret'];
+			$this->key = $row['consumer_key'];
+		}
+
+		/**
+		 * @param $securityToken
+		 * @param $guid
+		 * @param $springbotStoreId
+		 *
+		 * @return bool
+		 */
+		private function save_springbot_data( $securityToken, $guid, $springbotStoreId ) {
+			if ( $user = get_user_by( 'login', SPRINGBOT_WP_USER ) ) {
+				update_user_meta( $user->ID, 'springbot_security_token', $securityToken );
+				update_user_meta( $user->ID, 'springbot_store_guid', $guid );
+				update_user_meta( $user->ID, 'springbot_store_id', $springbotStoreId );
+
+				return true;
+			}
+
+			return false;
+		}
+
+		/**
+		 * Options page callback
+		 */
+		public function create_admin_page() {
+
+			$activation = new Springbot_Activation();
+			echo '<div class="wrap">';
+			echo '<h1>Springbot Options</h1>';
+			echo '<form method="post" action="' . esc_url( admin_url( 'admin.php' ) ) . '?page=springbot-options">';
+			echo '<input type="hidden" name="springbot[action]" value="edit_options">';
+			settings_fields( 'springbot_option_group' );
+			do_settings_sections( 'springbot-sync-options' );
+			submit_button();
+			echo '</form>';
+			echo '<h2>Springbot API Secret/Key</h2>';
+			echo '<p>The Springbot sync process is currently using the WP_USER <b>' . SPRINGBOT_WP_USER . '</b>.<br> You can modify which user is being used under config/springbot_config.php<br>';
+			echo '<input type="text" id="consumer-secret" name="springbot[consumer-secret]" value="' . $this->secret . '"  readonly="readonly" /><br>';
+			echo '<input type="text" id="consumer-key" name="springbot[consumer-key]" value="' . $this->key . '"  readonly="readonly" /><br>';
+			echo '</div>';
+		}
+
+		/**
+		 * Show an the appropriate error message on failure
+		 */
+		function my_error_notice() {
+			if ( isset( $_GET['msg'] ) ) {
+				if ( isset( $this->messages[ $_GET['msg'] ] ) ) {
+					$message = $this->messages[ $_GET['msg'] ];
+				} else {
+					$message = $this->messages['default'];
+				}
+				?>
+                <div class="error notice">
+                    <p><?php _e( $message ); ?></p>
+                </div>
+				<?php
+			}
+		}
+
+		/**
+		 * Register and add settings
+		 */
+		public function page_init() {
+			register_setting(
+				'springbot_option_group',
+				'springbot_option_name',
+				array( $this, 'sanitize' )
+			);
+
+			add_settings_section(
+				'setting_section_id',
+				'Springbot Sync Options',
+				array( $this, 'print_section_info' ),
+				'springbot-sync-options'
+			);
+
+			add_settings_field(
+				'springbot-guid',
+				'Store GUID',
+				array( $this, 'guid_callback' ),
+				'springbot-sync-options',
+				'setting_section_id'
+			);
+
+			add_settings_field(
+				'springbot-store-id',
+				'Store ID',
+				array( $this, 'storeid_callback' ),
+				'springbot-sync-options',
+				'setting_section_id'
+			);
+
+			add_settings_field(
+				'springbot-security-key',
+				'Store Security Key',
+				array( $this, 'securitykey_callback' ),
+				'springbot-sync-options',
+				'setting_section_id'
+			);
+		}
+
+		/**
+		 * Print the Section text
+		 */
+		public function print_section_info() {
+			echo 'This page allows you to edit your Springbot sync options. Please do NOT modify these settings unless instructed by springbot. This can break your springbot connection if modified improperly.';
+		}
+
+		/**
+		 * Get the settings option array and print one of its values
+		 */
+		public function guid_callback() {
+			echo '<input type="text" id="guid" name="springbot[guid]" value="' . $this->guid . '" />';
+		}
+
+		/**
+		 * Get the settings option array and print one of its values
+		 */
+		public function storeid_callback() {
+			echo '<input type="text" id="store-id" name="springbot[store-id]" value="' . $this->storeId . '" />';
+		}
+
+		/**
+		 * Get the settings option array and print one of its values
+		 */
+		public function securitykey_callback() {
+			echo '<input type="text" id="security-key" name="springbot[security-key]" value="' . $this->securityKey . '" />';
+		}
+
+	}
+
+}

--- a/config/springbot_config.php
+++ b/config/springbot_config.php
@@ -17,3 +17,7 @@ define( 'SPRINGBOT_ASSETS_DOMAIN',
 define( 'SPRINGBOT_APP_URL',
 	getenv( 'SPRINGBOT_APP_URL' ) ? getenv( 'SPRINGBOT_APP_URL' ) : 'https://app.springbot.com'
 );
+
+define( 'SPRINGBOT_WP_USER',
+	getenv( 'SPRINGBOT_WP_USER' ) ? getenv( 'SPRINGBOT_WP_USER' ) : 'springbot'
+);

--- a/config/springbot_config.php
+++ b/config/springbot_config.php
@@ -1,6 +1,6 @@
 <?php
 
-define( 'SPRINGBOT_PLUGIN_VERSION', '0.0.12.400' );
+define( 'SPRINGBOT_PLUGIN_VERSION', '0.0.13.400' );
 
 define( 'SPRINGBOT_NAME', 'WooCommerce Springbot Integration' );
 define( 'SPRINGBOT_REQUIRED_PHP_VERSION', '5.3' );

--- a/config/springbot_config.php
+++ b/config/springbot_config.php
@@ -7,7 +7,7 @@ define( 'SPRINGBOT_REQUIRED_PHP_VERSION', '5.3' );
 define( 'SPRINGBOT_REQUIRED_WP_VERSION', '3.1' );
 
 define( 'SPRINGBOT_WOO_ETL',
-	getenv( 'SPRINGBOT_WOO_ETL' ) ? getenv( 'SPRINGBOT_WOO_ETL' ) : 'http://etl.springbot.com'
+	getenv( 'SPRINGBOT_WOO_ETL' ) ? getenv( 'SPRINGBOT_WOO_ETL' ) : 'https://etl.springbot.com'
 );
 
 define( 'SPRINGBOT_ASSETS_DOMAIN',

--- a/config/springbot_config.php
+++ b/config/springbot_config.php
@@ -7,7 +7,7 @@ define( 'SPRINGBOT_REQUIRED_PHP_VERSION', '5.3' );
 define( 'SPRINGBOT_REQUIRED_WP_VERSION', '3.1' );
 
 define( 'SPRINGBOT_WOO_ETL',
-	getenv( 'SPRINGBOT_WOO_ETL' ) ? getenv( 'SPRINGBOT_WOO_ETL' ) : 'https://woo-etl-api-prod.herokuapp.com'
+	getenv( 'SPRINGBOT_WOO_ETL' ) ? getenv( 'SPRINGBOT_WOO_ETL' ) : 'http://etl.springbot.com'
 );
 
 define( 'SPRINGBOT_ASSETS_DOMAIN',

--- a/woocommerce-springbot.php
+++ b/woocommerce-springbot.php
@@ -3,7 +3,7 @@
  * Plugin Name: Springbot WooCommerce Integration
  * Plugin URI: https://www.springbot.com/
  * Description: Integration plugin between WooCommerce and Springbot
- * Version: 0.0.12
+ * Version: 0.0.13
  * Author: Springbot
  *
  * @package Woocommerce_Springbot

--- a/woocommerce-springbot.php
+++ b/woocommerce-springbot.php
@@ -38,6 +38,7 @@ if ( ! class_exists( 'WooCommerce_Springbot' ) ) {
 			require_once( __DIR__ . '/classes/springbot_product.php' );
 			require_once( __DIR__ . '/classes/springbot_footer.php' );
 			require_once( __DIR__ . '/classes/springbot_options.php' );
+			require_once( __DIR__ . '/classes/springbot_user_options.php' );
 			require_once( __DIR__ . '/classes/springbot_redirect.php' );
 			require_once( __DIR__ . '/classes/springbot_webhooks.php' );
 
@@ -62,6 +63,7 @@ if ( ! class_exists( 'WooCommerce_Springbot' ) ) {
 				if ( is_admin() ) {
 
 					add_action( 'admin_menu', array( $this, 'springbot_menu_page' ) );
+					add_action( 'admin_menu', array( $this, 'springbot_options_page' ) );
 					add_action( 'pre_user_query', array( 'WooCommerce_Springbot', 'hide_springbot_api_user' ) );
 
 				} else {
@@ -99,6 +101,23 @@ if ( ! class_exists( 'WooCommerce_Springbot' ) ) {
 			global $wpdb;
 			$user_search->query_where = str_replace( 'WHERE 1=1',
 				"WHERE 1=1 AND {$wpdb->users}.user_login != '" . SPRINGBOT_WP_USER . "'", $user_search->query_where );
+		}
+
+		public function springbot_options_page() {
+			if ( class_exists( 'Springbot_Activation' ) ) {
+				$springbot_activation = new Springbot_Activation;
+				if ( class_exists( 'Springbot_User_Options' ) ) {
+					$springbot_options = new Springbot_User_Options( $springbot_activation );
+					add_submenu_page(
+						null,
+						'Springbot Sync Options',
+						'Options',
+						'manage_options',
+						'springbot-options',
+						array( $springbot_options, 'create_admin_page' )
+					);
+				}
+			}
 		}
 
 		public function springbot_menu_page() {

--- a/woocommerce-springbot.php
+++ b/woocommerce-springbot.php
@@ -98,7 +98,7 @@ if ( ! class_exists( 'WooCommerce_Springbot' ) ) {
 		public static function hide_springbot_api_user( $user_search ) {
 			global $wpdb;
 			$user_search->query_where = str_replace( 'WHERE 1=1',
-				"WHERE 1=1 AND {$wpdb->users}.user_login != 'springbot'", $user_search->query_where );
+				"WHERE 1=1 AND {$wpdb->users}.user_login != '" . SPRINGBOT_WP_USER . "'", $user_search->query_where );
 		}
 
 		public function springbot_menu_page() {


### PR DESCRIPTION
This is to add a couple of QOL changes.

With this we can
easily access the CS and CK from the WP admin
easily changes apiKey, GUID, and even store ID from the plugin
easily modify the user we are using to store the sync settings. 

all accessible from ```admin.php?page=springbot-options``` but completely unlisted to the user