### PR TITLE
SB3-1588 Fix for Springbot Variable on Footer

### DIFF
--- a/classes/springbot_footer.php
+++ b/classes/springbot_footer.php
@@ -39,10 +39,6 @@ if ( ! class_exists( 'Springbot_Footer' ) ) {
 					echo "  pixel.className = 'sb-pixel';\n";
 					echo "  pixelContainer.appendChild(pixel);\n";
 					echo "  document.body.appendChild(pixelContainer);\n";
-
-					// Set the product_id for our async script to use if needed
-					echo "  var Springbot = Springbot || {};\n";
-					echo "  Springbot.product_id = \"{$product->get_id()}\";\n";
 					echo "});\n";
 
 				}
@@ -50,6 +46,14 @@ if ( ! class_exists( 'Springbot_Footer' ) ) {
 				echo "  })();\n";
 				echo "</script>\n";
 
+				if ( is_product() && ( $product instanceof WC_Product ) ) {
+					// Set the product_id for our async script to use if needed
+					echo "<script data-cfasync=\"false\" type=\"text/javascript\">\n";
+					echo "  var Springbot = Springbot || {};\n";
+					echo "  Springbot.product_id = \"{$product->get_id()}\";\n";
+					echo "</script>\n";
+				}
+				
 				// Load AdRoll conversion tracking on checkout success (aka order received) page
 				if ( is_order_received_page() ) {
 					$order_id = isset( $wp->query_vars['order-received'] ) ? intval( $wp->query_vars['order-received'] ) : null;

--- a/config/springbot_config.php
+++ b/config/springbot_config.php
@@ -1,6 +1,6 @@
 <?php
 
-define( 'SPRINGBOT_PLUGIN_VERSION', '1.0.1.400' );
+define( 'SPRINGBOT_PLUGIN_VERSION', '1.0.2.400' );
 
 define( 'SPRINGBOT_NAME', 'WooCommerce Springbot Integration' );
 define( 'SPRINGBOT_REQUIRED_PHP_VERSION', '5.3' );

--- a/woocommerce-springbot.php
+++ b/woocommerce-springbot.php
@@ -3,7 +3,7 @@
  * Plugin Name: Springbot WooCommerce Integration
  * Plugin URI: https://www.springbot.com/
  * Description: Integration plugin between WooCommerce and Springbot
- * Version: 0.0.17
+ * Version: 1.0.2
  * Author: Springbot
  *
  * @package Woocommerce_Springbot


### PR DESCRIPTION
Tested and currently deployed on https://www.saleturf.com/test-sites/wordpress/product/this-is-my-test-product/

This moves the Springbot variable outside of the on-load event that is blocking the variable from being executable by adroll.