### PR TITLE
SB3-3151 - Add key check to thank you page

### DIFF
--- a/classes/springbot_footer.php
+++ b/classes/springbot_footer.php
@@ -56,7 +56,11 @@ if ( ! class_exists( 'Springbot_Footer' ) ) {
 				
 				// Load AdRoll conversion tracking on checkout success (aka order received) page
 				if ( is_order_received_page() ) {
-					$order_id = isset( $wp->query_vars['order-received'] ) ? intval( $wp->query_vars['order-received'] ) : null;
+					if(empty( $_GET['key'] )) {
+						$order_id = isset( $wp->query_vars['order-received'] ) ? intval( $wp->query_vars['order-received'] ) : null;
+					} else {
+						$order_id = wc_get_order_id_by_order_key( $_GET['key'] );
+					}
 					if ( $order_id ) {
 						$order = new WC_Order( $order_id );
 						if ( $order instanceof WC_Order ) {


### PR DESCRIPTION
According to documentation, this should work in verifying the order_id on both custom thank you pages and the standard order-received page. 

All we are doing is first checking for the order_id by the URL key param if available, if not available then we fall back to the original check which uses the value in the /order-received url.